### PR TITLE
Add support for X509 mutual authentication/authorization

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,1 +1,1 @@
-We are in the process of cleaning internal references and open-sourcing this portion of the DBoM node. Stay Tuned!
+Go to a subfolder to view the README for each service.

--- a/charts/database-agent/Chart.yaml
+++ b/charts/database-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: database-agent
-description: A Helm chart for Kubernetes
+description: A chart that deploys the DBoM database agent. Note that you need to set up a mongodb instance that the agent can connect to 
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/database-agent/README.md
+++ b/charts/database-agent/README.md
@@ -7,13 +7,14 @@ This Helm chart is a lightweight way to configure and run the official
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Requirements](#requirements)
-- [Installing](#installing)
-  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using master branch](#install-development-version-using-master-branch)
-- [Upgrading](#upgrading)
-- [Mongo DB](#mongo-db)
-- [Configuration](#configuration)
+- [DBoM Database Agent Chart](#dbom-database-agent-chart)
+  - [Requirements](#requirements)
+  - [Installing](#installing)
+    - [Install released version using Helm repository](#install-released-version-using-helm-repository)
+    - [Install development version using master branch](#install-development-version-using-master-branch)
+  - [Upgrading](#upgrading)
+  - [Mongo DB](#mongo-db)
+  - [Configuration](#configuration)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- Use this to update TOC: -->
@@ -61,44 +62,55 @@ This Helm chart is a lightweight way to configure and run the official
 
 ## Configuration
 
-| Parameter                           | Description                                                        | Default                                 |
-|-------------------------------------|--------------------------------------------------------------------|-----------------------------------------|
-| `affinity`                          | Configurable [affinity]                                            | {}                                      |
-| `fullnameOverride`                  | Overrides the full name of the resources. "                        | `""`                                    |
-| `image.repository`                  | `database-agent` image repository                                  | `dbomproject/database-agent`            |
-| `image.tag`                         | `database-agent` image tag                                         | `1.0.0`                                 |
-| `image.pullPolicy`                  | The Kubernetes [imagePullPolicy] value                             | `IfNotPresent`                          |
-| `imagePullSecrets`                  | Configuration for [imagePullSecrets] for using a private registry  | `[]`                                    |
-| `databaseAgent.depname`             | Deployment name                                                    | `database-agent`                        |
-| `databaseAgent.mongohost`           | Mongo host to connect to                                           | `mongodb`                               |
-| `databaseAgent.mongoPasswordKey`    | Name of the secret key that has the password                       | `mongodb-root-password`                 |
-| `databaseAgent.mongoReplicaSetName` | Replica set name given to the mongodb cluster                      | `rs0`                                   |
-| `databaseAgent.mongoSecret`         | Name of the kubernetes secret that holds the password              | `mongodb`                               |
-| `databaseAgent.port`                | Port the agent uses                                                | `3500`                                  |
-| `ingress`                           | [ingress] to expose the database agent service.                    | see [values.yaml]                       |
-| `jaeger.agent.sidecar.enabled`      | Is Jaeger Agent Sidecar Injection Enabled                          | `false`                                 |
-| `jaeger.agent.sidecar.name`         | The deployed jaeger to connect to                                  | `true`                                  |
-| `jaeger.enabled`                    | Is jaeger tracing enabled                                          | `false`                                 |
-| `jaeger.host`                       | The jaeger host to send traces to                                  | ``                                      |
-| `jaeger.sampler.type`               | The jaeger sampler type to use                                     | `const`                                 |
-| `jaeger.sampler.param`              | The parameter to pass to the jaeger sampler                        | `1`                                     |
-| `jaeger.serviceName`                | The name of the service passed to jaeger                           | `database Agent`                        |
-| `labels`                            | Configurable [labels] applied to all database agent pods           | {}                                      |
-| `logging.level`                     | The logging level                                                  | `info`                                  |
-| `nameOverride`                      | Overrides the chart name for resources. default to `.Chart.Name`   | `""`                                    |
-| `nodeSelector`                      | Configurable [nodeSelector]                                        | `{}`                                    |
-| `persistence.accessMode`            | Access mode for the volume                                         | `ReadWriteOnce`                         |
-| `persistence.annotations`           | Annotations for the volume                                         | {}                                      |
-| `persistence.enabled`               | Enable a persistent volume                                         | true                                    |
-| `persistence.size`                  | Size of volume                                                     | `1Gi`                                   |
-| `persistence.storageClass`          | Storage class to use                                               | `nfs-client`                            |
-| `podAnnotations`                    | Configurable [annotations]                                         | {}                                      |
-| `podSecurityContext`                | Allows you to set the [securityContext] for the pod                | see [values.yaml]                       |
-| `resources`                         | Allows you to set the [resources] for the Deployment               | see [values.yaml]                       |
-| `securityContext`                   | Allows you to set the [securityContext] for the container          | see [values.yaml]                       |
-| `service`                           | Configurable [service][] to expose the database agent              | see [values.yaml]                       |
-| `serviceAccount`                    | Allows you to overwrite the "default" [serviceAccount] for the pod | see [values.yaml]                       |
-| `tolerations`                       | Configurable [tolerations][]                                       | `[]`                                    |
+| Parameter                                            | Description                                                                | Default                      |
+| ---------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------- |
+| `affinity`                                           | Configurable [affinity]                                                    | {}                           |
+| `fullnameOverride`                                   | Overrides the full name of the resources. "                                | `""`                         |
+| `image.repository`                                   | `database-agent` image repository                                          | `dbomproject/database-agent` |
+| `image.tag`                                          | `database-agent` image tag                                                 | `1.0.0`                      |
+| `image.pullPolicy`                                   | The Kubernetes [imagePullPolicy] value                                     | `IfNotPresent`               |
+| `imagePullSecrets`                                   | Configuration for [imagePullSecrets] for using a private registry          | `[]`                         |
+| `databaseAgent.depname`                              | Deployment name                                                            | `database-agent`             |
+| `databaseAgent.mongohost`                            | Mongo host to connect to                                                   | `mongodb`                    |
+| `databaseAgent.mongoPasswordKey`                     | Name of the secret key that has the password                               | `mongodb-root-password`      |
+| `databaseAgent.mongoReplicaSetName`                  | Replica set name given to the mongodb cluster                              | `rs0`                        |
+| `databaseAgent.mongoSecret`                          | Name of the kubernetes secret that holds the password                      | `mongodb`                    |
+| `databaseAgent.port`                                 | Port the agent uses                                                        | `3500`                       |
+| `databaseAgent.mongoServerSelectionTimeout`          | Timeout for server selection                                               | `3000`                       |
+| `databaseAgent.mongoConnectionTimeout`               | Timeout for initial connection to mongodb                                  | `3000`                       |
+| `databaseAgent.mongoTLS.enabled`                     | Whether TLS connections and X509 authentication & authorization is enabled | `false`                      |
+| `databaseAgent.mongoTLS.allowInvalidHosts`           | Whether the host portion of the certificate is validated                   | `false`                      |
+| `databaseAgent.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `-`                          |
+| `databaseAgent.mongoTLS.certs.secretPath`            | Path where certificates in the secret are to be mounted                    | `/secrets/`                  |
+| `databaseAgent.mongoTLS.certs.caCertKey`             | The key in the secret where the CA certificate is declared                 | `ca.pem`                     |
+| `databaseAgent.mongoTLS.certs.clientCertKey`         | The key in the secret where the client certificate is declared             | `client.pem`                 |
+| `databaseAgent.mongoTLS.certs.clientCertIsEncrypted` | Whether the client certificate is encrypted with a passphrase              | `false`                      |
+| `databaseAgent.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `-`                          |
+| `databaseAgent.mongoTLS.certs.clientCertPassKey`     | If client certificate is encrypted, key of the passkey in the secret       | `MONGO_TLS_CLIENT_CERT_PASS` |
+| `ingress`                                            | [ingress] to expose the database agent service.                            | see [values.yaml]            |
+| `jaeger.agent.sidecar.enabled`                       | Is Jaeger Agent Sidecar Injection Enabled                                  | `false`                      |
+| `jaeger.agent.sidecar.name`                          | The deployed jaeger to connect to                                          | `true`                       |
+| `jaeger.enabled`                                     | Is jaeger tracing enabled                                                  | `false`                      |
+| `jaeger.host`                                        | The jaeger host to send traces to                                          | ``                           |
+| `jaeger.sampler.type`                                | The jaeger sampler type to use                                             | `const`                      |
+| `jaeger.sampler.param`                               | The parameter to pass to the jaeger sampler                                | `1`                          |
+| `jaeger.serviceName`                                 | The name of the service passed to jaeger                                   | `database Agent`             |
+| `labels`                                             | Configurable [labels] applied to all database agent pods                   | {}                           |
+| `logging.level`                                      | The logging level                                                          | `info`                       |
+| `nameOverride`                                       | Overrides the chart name for resources. default to `.Chart.Name`           | `""`                         |
+| `nodeSelector`                                       | Configurable [nodeSelector]                                                | `{}`                         |
+| `persistence.accessMode`                             | Access mode for the volume                                                 | `ReadWriteOnce`              |
+| `persistence.annotations`                            | Annotations for the volume                                                 | {}                           |
+| `persistence.enabled`                                | Enable a persistent volume                                                 | true                         |
+| `persistence.size`                                   | Size of volume                                                             | `1Gi`                        |
+| `persistence.storageClass`                           | Storage class to use                                                       | `nfs-client`                 |
+| `podAnnotations`                                     | Configurable [annotations]                                                 | {}                           |
+| `podSecurityContext`                                 | Allows you to set the [securityContext] for the pod                        | see [values.yaml]            |
+| `resources`                                          | Allows you to set the [resources] for the Deployment                       | see [values.yaml]            |
+| `securityContext`                                    | Allows you to set the [securityContext] for the container                  | see [values.yaml]            |
+| `service`                                            | Configurable [service][] to expose the database agent                      | see [values.yaml]            |
+| `serviceAccount`                                     | Allows you to overwrite the "default" [serviceAccount] for the pod         | see [values.yaml]            |
+| `tolerations`                                        | Configurable [tolerations][]                                               | `[]`                         |
    
    
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/database-agent/README.md
+++ b/charts/database-agent/README.md
@@ -65,7 +65,7 @@ This Helm chart is a lightweight way to configure and run the official
 | Parameter                                            | Description                                                                | Default                      |
 | ---------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------- |
 | `affinity`                                           | Configurable [affinity]                                                    | {}                           |
-| `fullnameOverride`                                   | Overrides the full name of the resources. "                                | `""`                         |
+| `fullnameOverride`                                   | Overrides the full name of the resources.                                  | `""`                         |
 | `image.repository`                                   | `database-agent` image repository                                          | `dbomproject/database-agent` |
 | `image.tag`                                          | `database-agent` image tag                                                 | `1.0.0`                      |
 | `image.pullPolicy`                                   | The Kubernetes [imagePullPolicy] value                                     | `IfNotPresent`               |
@@ -80,12 +80,12 @@ This Helm chart is a lightweight way to configure and run the official
 | `databaseAgent.mongoConnectionTimeout`               | Timeout for initial connection to mongodb                                  | `3000`                       |
 | `databaseAgent.mongoTLS.enabled`                     | Whether TLS connections and X509 authentication & authorization is enabled | `false`                      |
 | `databaseAgent.mongoTLS.allowInvalidHosts`           | Whether the host portion of the certificate is validated                   | `false`                      |
-| `databaseAgent.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `-`                          |
+| `databaseAgent.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `""`                         |
 | `databaseAgent.mongoTLS.certs.secretPath`            | Path where certificates in the secret are to be mounted                    | `/secrets/`                  |
 | `databaseAgent.mongoTLS.certs.caCertKey`             | The key in the secret where the CA certificate is declared                 | `ca.pem`                     |
 | `databaseAgent.mongoTLS.certs.clientCertKey`         | The key in the secret where the client certificate is declared             | `client.pem`                 |
 | `databaseAgent.mongoTLS.certs.clientCertIsEncrypted` | Whether the client certificate is encrypted with a passphrase              | `false`                      |
-| `databaseAgent.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `-`                          |
+| `databaseAgent.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `""`                         |
 | `databaseAgent.mongoTLS.certs.clientCertPassKey`     | If client certificate is encrypted, key of the passkey in the secret       | `MONGO_TLS_CLIENT_CERT_PASS` |
 | `ingress`                                            | [ingress] to expose the database agent service.                            | see [values.yaml]            |
 | `jaeger.agent.sidecar.enabled`                       | Is Jaeger Agent Sidecar Injection Enabled                                  | `false`                      |

--- a/charts/database-agent/templates/configmap.yaml
+++ b/charts/database-agent/templates/configmap.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{.Values.databaseAgent.depname}}-config
+  name: {{ .Values.databaseAgent.depname }}-config
 data:
-  LOG_LEVEL: {{ .Values.logging.level }}
-  MONGO_HOST: {{ .Values.databaseAgent.mongohost }}
-  MONGO_PASS_KEY: {{ .Values.databaseAgent.mongoPasswordKey }}
+  LOG_LEVEL: {{ .Values.logging.level | quote }}
+  PORT: {{ .Values.databaseAgent.port | quote }}
+  MONGO_HOST: {{ .Values.databaseAgent.mongohost | quote }}
+  MONGO_PASS_KEY: {{ .Values.databaseAgent.mongoPasswordKey | quote }}
   MONGO_PORT: "27017"
   MONGO_USER: root
-  MONGO_REPLICA_SET_NAME: {{ .Values.databaseAgent.mongoReplicaSetName }}
+  MONGO_REPLICA_SET_NAME: {{ .Values.databaseAgent.mongoReplicaSetName | quote }}
   CHANNEL_DB: primary
   AUDIT_POSTFIX: _audit
   JAEGER_ENABLED: {{.Values.jaeger.enabled | quote }}
@@ -17,3 +18,16 @@ data:
   JAEGER_SAMPLER_TYPE: {{.Values.jaeger.sampler.type | quote }}
   JAEGER_SERVICE_NAME: {{.Values.jaeger.serviceName | quote }}
   JAEGER_AGENT_SIDECAR_ENABLED: {{.Values.jaeger.agent.sidecar.enabled | quote }}
+  MONGO_SERVER_SELECTION_TIMEOUT: {{ .Values.databaseAgent.mongoServerSelectionTimeout }}
+  MONGO_CONNECTION_TIMEOUT: {{ .Values.databaseAgent.mongoConnectionTimeout }}
+  {{ if .Values.databaseAgent.mongoTLS.enabled }}
+  MONGO_TLS_MODE_ENABLED: "1"
+  MONGO_TLS_CA_CERT_PATH: {{ .Values.databaseAgent.mongoTLS.certs.secretPath }}{{ .Values.databaseAgent.mongoTLS.certs.caCertKey }}
+  MONGO_TLS_CLIENT_CERT_PATH: {{ .Values.databaseAgent.mongoTLS.certs.secretPath }}{{ .Values.databaseAgent.mongoTLS.certs.clientCertKey }}
+  {{ if .Values.databaseAgent.mongoTLS.allowInvalidHosts }}
+  MONGO_TLS_ALLOW_INVALID_HOST: "1" 
+  {{ end }}
+  {{ if .Values.databaseAgent.mongoTLS.certs.clientCertIsEncrypted }}
+  MONGO_TLS_CLIENT_CERT_PASS_KEY: {{ .Values.databaseAgent.mongoTLS.certs.clientCertPassKey | quote}}
+  {{ end }}
+  {{ end }}

--- a/charts/database-agent/templates/deployment.yaml
+++ b/charts/database-agent/templates/deployment.yaml
@@ -37,13 +37,23 @@ spec:
               protocol: TCP
           envFrom:
             - configMapRef:
-                name: {{.Values.databaseAgent.depname}}-config
+                name: {{ .Values.databaseAgent.depname }}-config
             - secretRef:
-                name: {{.Values.databaseAgent.mongoSecret}}
+                name: {{ .Values.databaseAgent.mongoSecret }}
+          {{ if .Values.databaseAgent.mongoTLS.certs.clientCertIsEncrypted }}
+            - secretRef:
+                name: {{ .Values.databaseAgent.mongoTLS.certs.clientCertPassSecret }}
+          {{ end }}
           readinessProbe:
             httpGet:
               path: /
               port: http
+          {{ if .Values.databaseAgent.mongoTLS.enabled }}
+          volumeMounts:
+            - name: certs-vol
+              mountPath: {{ .Values.databaseAgent.mongoTLS.certs.secretPath }}
+              readOnly: true
+          {{ end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -58,3 +68,9 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{ if .Values.databaseAgent.mongoTLS.enabled }}
+      volumes:
+      - name: certs-vol
+        secret:
+          secretName: {{ .Values.databaseAgent.mongoTLS.certs.secret }}
+    {{ end }}

--- a/charts/database-agent/values.yaml
+++ b/charts/database-agent/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   repository: dbomproject/database-agent
+  tag: latest
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -13,12 +14,26 @@ nameOverride: ""
 fullnameOverride: ""
 
 databaseAgent:
-  port: "3500"
+  port: 3500
   mongohost: mongodb
   depname: database-agent
   mongoPasswordKey: mongodb-root-password
   mongoSecret: mongodb
   mongoReplicaSetName: rs0
+  mongoServerSelectionTimeout: 3000
+  mongoConnectionTimeout: 3000
+  mongoTLS: 
+    enabled: false
+    allowInvalidHosts: false
+    certs:
+      secret: ""
+      secretPath: /secrets/
+      caCertKey: ca.pem
+      clientCertKey: client.pem
+      clientCertIsEncrypted: false 
+      clientCertPassSecret: ""
+      clientCertPassKey: "MONGO_TLS_CLIENT_CERT_PASS"
+    
 
 logging:
   level: info

--- a/charts/mongodb-audit-watcher/README.md
+++ b/charts/mongodb-audit-watcher/README.md
@@ -65,7 +65,7 @@ This Helm chart is a lightweight way to configure and run the official
 | Parameter                                                  | Description                                                                | Default                             |
 | ---------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------- |
 | `affinity`                                                 | Configurable [affinity]                                                    | {}                                  |
-| `fullnameOverride`                                         | Overrides the full name of the resources. "                                | `""`                                |
+| `fullnameOverride`                                         | Overrides the full name of the resources.                                  | `""`                                |
 | `image.repository`                                         | `database-agent` image repository                                          | `dbomproject/mongodb-audit-watcher` |
 | `image.tag`                                                | `database-agent` image tag                                                 | `1.0.0`                             |
 | `image.pullPolicy`                                         | The Kubernetes [imagePullPolicy] value                                     | `IfNotPresent`                      |
@@ -79,12 +79,12 @@ This Helm chart is a lightweight way to configure and run the official
 | `mongoDBAuditWatcher.mongoConnectionTimeout`               | Timeout for initial connection to mongodb                                  | `3000`                              |
 | `mongoDBAuditWatcher.mongoTLS.enabled`                     | Whether TLS connections and X509 authentication & authorization is enabled | `false`                             |
 | `mongoDBAuditWatcher.mongoTLS.allowInvalidHosts`           | Whether the host portion of the certificate is validated                   | `false`                             |
-| `mongoDBAuditWatcher.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `-`                                 |
+| `mongoDBAuditWatcher.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `""`                                 |
 | `mongoDBAuditWatcher.mongoTLS.certs.secretPath`            | Path where certificates in the secret are to be mounted                    | `/secrets/`                         |
 | `mongoDBAuditWatcher.mongoTLS.certs.caCertKey`             | The key in the secret where the CA certificate is declared                 | `ca.pem`                            |
 | `mongoDBAuditWatcher.mongoTLS.certs.clientCertKey`         | The key in the secret where the client certificate is declared             | `client.pem`                        |
 | `mongoDBAuditWatcher.mongoTLS.certs.clientCertIsEncrypted` | Whether the client certificate is encrypted with a passphrase              | `false`                             |
-| `mongoDBAuditWatcher.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `-`                                 |
+| `mongoDBAuditWatcher.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `""`                                 |
 | `mongoDBAuditWatcher.mongoTLS.certs.clientCertPassKey`     | If client certificate is encrypted, key of the passkey in the secret       | `MONGO_TLS_CLIENT_CERT_PASS`        |
 | `labels`                                                   | Configurable [labels] applied to all database agent pods                   | {}                                  |
 | `logging.level`                                            | The logging level                                                          | `info`                              |

--- a/charts/mongodb-audit-watcher/README.md
+++ b/charts/mongodb-audit-watcher/README.md
@@ -7,13 +7,14 @@ This Helm chart is a lightweight way to configure and run the official
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Requirements](#requirements)
-- [Installing](#installing)
-  - [Install released version using Helm repository](#install-released-version-using-helm-repository)
-  - [Install development version using master branch](#install-development-version-using-master-branch)
-- [Upgrading](#upgrading)
-- [Mongo DB](#mongo-db)
-- [Configuration](#configuration)
+- [DBoM MongoDB Audit Watcher Helm Chart](#dbom-mongodb-audit-watcher-helm-chart)
+  - [Requirements](#requirements)
+  - [Installing](#installing)
+    - [Install released version using Helm repository](#install-released-version-using-helm-repository)
+    - [Install development version using master branch](#install-development-version-using-master-branch)
+  - [Upgrading](#upgrading)
+  - [Mongo DB](#mongo-db)
+  - [Configuration](#configuration)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 <!-- Use this to update TOC: -->
@@ -61,35 +62,46 @@ This Helm chart is a lightweight way to configure and run the official
 
 ## Configuration
 
-| Parameter                               | Description                                                        | Default                                        |
-|-----------------------------------------|--------------------------------------------------------------------|------------------------------------------------|
-| `affinity`                              | Configurable [affinity]                                            | {}                                             |
-| `fullnameOverride`                      | Overrides the full name of the resources. "                        | `""`                                           |
-| `image.repository`                      | `database-agent` image repository                                  | `dbomproject/mongodb-audit-watcher`            |
-| `image.tag`                             | `database-agent` image tag                                         | `1.0.0`                                        |
-| `image.pullPolicy`                      | The Kubernetes [imagePullPolicy] value                             | `IfNotPresent`                                 |
-| `imagePullSecrets`                      | Configuration for [imagePullSecrets] for using a private registry  | `[]`                                           |
-| `mongoAuditWatcher.persistPath`         | Path to persistent storage                                         | `database-agent`                               |
-| `mongoAuditWatcher.mongohost`           | Mongo host to connect to                                           | `mongodb`                                      |
-| `mongoAuditWatcher.mongoReplicaSetName` | Replica set name given to the mongodb cluster                      | `rs0`                                          |
-| `mongoAuditWatcher.mongoPasswordKey`    | Name of the secret key that has the password                       | `mongodb-root-password`                        |
-| `mongoAuditWatcher.mongoSecret`         | Name of the kubernetes secret that holds the password              | `mongodb`                                      |
-| `labels`                                | Configurable [labels] applied to all database agent pods           | {}                                             |
-| `logging.level`                         | The logging level                                                  | `info`                                         |
-| `nameOverride`                          | Overrides the chart name for resources. default to `.Chart.Name`   | `""`                                           |
-| `nodeSelector`                          | Configurable [nodeSelector]                                        | `{}`                                           |
-| `persistence.accessMode`                | Access mode for the volume                                         | `ReadWriteOnce`                                |
-| `persistence.annotations`               | Annotations for the volume                                         | {}                                             |
-| `persistence.enabled`                   | Enable a persistent volume                                         | true                                           |
-| `persistence.size`                      | Size of volume                                                     | `1Gi`                                          |
-| `persistence.storageClass`              | Storage class to use                                               | `nfs-client`                                   |
-| `podAnnotations`                        | Configurable [annotations]                                         | {}                                             |
-| `podSecurityContext`                    | Allows you to set the [securityContext] for the pod                | see [values.yaml]                              |
-| `resources`                             | Allows you to set the [resources] for the Deployment               | see [values.yaml]                              |
-| `securityContext`                       | Allows you to set the [securityContext] for the container          | see [values.yaml]                              |
-| `service`                               | Configurable [service][] to expose the database agent              | see [values.yaml]                              |
-| `serviceAccount`                        | Allows you to overwrite the "default" [serviceAccount] for the pod | see [values.yaml]                              |
-| `tolerations`                           | Configurable [tolerations][]                                       | `[]`                                           |
+| Parameter                                                  | Description                                                                | Default                             |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------- |
+| `affinity`                                                 | Configurable [affinity]                                                    | {}                                  |
+| `fullnameOverride`                                         | Overrides the full name of the resources. "                                | `""`                                |
+| `image.repository`                                         | `database-agent` image repository                                          | `dbomproject/mongodb-audit-watcher` |
+| `image.tag`                                                | `database-agent` image tag                                                 | `1.0.0`                             |
+| `image.pullPolicy`                                         | The Kubernetes [imagePullPolicy] value                                     | `IfNotPresent`                      |
+| `imagePullSecrets`                                         | Configuration for [imagePullSecrets] for using a private registry          | `[]`                                |
+| `mongoAuditWatcher.persistPath`                            | Path to persistent storage                                                 | `database-agent`                    |
+| `mongoAuditWatcher.mongohost`                              | Mongo host to connect to                                                   | `mongodb`                           |
+| `mongoAuditWatcher.mongoReplicaSetName`                    | Replica set name given to the mongodb cluster                              | `rs0`                               |
+| `mongoAuditWatcher.mongoPasswordKey`                       | Name of the secret key that has the password                               | `mongodb-root-password`             |
+| `mongoAuditWatcher.mongoSecret`                            | Name of the kubernetes secret that holds the password                      | `mongodb`                           |
+| `mongoDBAuditWatcher.mongoServerSelectionTimeout`          | Timeout for server selection                                               | `3000`                              |
+| `mongoDBAuditWatcher.mongoConnectionTimeout`               | Timeout for initial connection to mongodb                                  | `3000`                              |
+| `mongoDBAuditWatcher.mongoTLS.enabled`                     | Whether TLS connections and X509 authentication & authorization is enabled | `false`                             |
+| `mongoDBAuditWatcher.mongoTLS.allowInvalidHosts`           | Whether the host portion of the certificate is validated                   | `false`                             |
+| `mongoDBAuditWatcher.mongoTLS.certs.secret`                | Name of secret where certificates are declared                             | `-`                                 |
+| `mongoDBAuditWatcher.mongoTLS.certs.secretPath`            | Path where certificates in the secret are to be mounted                    | `/secrets/`                         |
+| `mongoDBAuditWatcher.mongoTLS.certs.caCertKey`             | The key in the secret where the CA certificate is declared                 | `ca.pem`                            |
+| `mongoDBAuditWatcher.mongoTLS.certs.clientCertKey`         | The key in the secret where the client certificate is declared             | `client.pem`                        |
+| `mongoDBAuditWatcher.mongoTLS.certs.clientCertIsEncrypted` | Whether the client certificate is encrypted with a passphrase              | `false`                             |
+| `mongoDBAuditWatcher.mongoTLS.certs.clientCertPassSecret`  | If client certificate is encrypted, secret where passkey is stored         | `-`                                 |
+| `mongoDBAuditWatcher.mongoTLS.certs.clientCertPassKey`     | If client certificate is encrypted, key of the passkey in the secret       | `MONGO_TLS_CLIENT_CERT_PASS`        |
+| `labels`                                                   | Configurable [labels] applied to all database agent pods                   | {}                                  |
+| `logging.level`                                            | The logging level                                                          | `info`                              |
+| `nameOverride`                                             | Overrides the chart name for resources. default to `.Chart.Name`           | `""`                                |
+| `nodeSelector`                                             | Configurable [nodeSelector]                                                | `{}`                                |
+| `persistence.accessMode`                                   | Access mode for the volume                                                 | `ReadWriteOnce`                     |
+| `persistence.annotations`                                  | Annotations for the volume                                                 | {}                                  |
+| `persistence.enabled`                                      | Enable a persistent volume                                                 | true                                |
+| `persistence.size`                                         | Size of volume                                                             | `1Gi`                               |
+| `persistence.storageClass`                                 | Storage class to use                                                       | `nfs-client`                        |
+| `podAnnotations`                                           | Configurable [annotations]                                                 | {}                                  |
+| `podSecurityContext`                                       | Allows you to set the [securityContext] for the pod                        | see [values.yaml]                   |
+| `resources`                                                | Allows you to set the [resources] for the Deployment                       | see [values.yaml]                   |
+| `securityContext`                                          | Allows you to set the [securityContext] for the container                  | see [values.yaml]                   |
+| `service`                                                  | Configurable [service][] to expose the database agent                      | see [values.yaml]                   |
+| `serviceAccount`                                           | Allows you to overwrite the "default" [serviceAccount] for the pod         | see [values.yaml]                   |
+| `tolerations`                                              | Configurable [tolerations][]                                               | `[]`                                |
 
 
 [affinity]: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/charts/mongodb-audit-watcher/templates/configmap.yaml
+++ b/charts/mongodb-audit-watcher/templates/configmap.yaml
@@ -3,13 +3,26 @@ kind: ConfigMap
 metadata:
   name: {{ include "mongodb-audit-watcher.fullname" . }}-config
 data:
-  LOG_LEVEL: {{ .Values.logging.level }}
-  MONGO_HOST: {{ .Values.mongoDBAuditWatcher.mongohost }}
-  MONGO_PASS_KEY: {{ .Values.mongoDBAuditWatcher.mongoPasswordKey }}
+  LOG_LEVEL: {{ .Values.logging.level | quote }}
+  MONGO_HOST: {{ .Values.mongoDBAuditWatcher.mongohost | quote }}
+  MONGO_PASS_KEY: {{ .Values.mongoDBAuditWatcher.mongoPasswordKey | quote }}
   MONGO_PORT: "27017"
   MONGO_USER: root
-  MONGO_REPLICA_SET_NAME: {{ .Values.mongoDBAuditWatcher.mongoReplicaSetName }}
+  MONGO_REPLICA_SET_NAME: {{ .Values.mongoDBAuditWatcher.mongoReplicaSetName | quote }}
   CHANNEL_DB: primary
   AUDIT_POSTFIX: _audit
-  PERSIST_PATH: {{ .Values.mongoDBAuditWatcher.persistPath }}
+  PERSIST_PATH: {{ .Values.mongoDBAuditWatcher.persistPath | quote }}
+  MONGO_SERVER_SELECTION_TIMEOUT: {{ .Values.mongoDBAuditWatcher.mongoServerSelectionTimeout | quote }}
+  MONGO_CONNECTION_TIMEOUT: {{ .Values.mongoDBAuditWatcher.mongoConnectionTimeout | quote }}
+  {{ if .Values.mongoDBAuditWatcher.mongoTLS.enabled }}
+  MONGO_TLS_MODE_ENABLED: "1"
+  MONGO_TLS_CA_CERT_PATH: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.secretPath }}{{ .Values.mongoDBAuditWatcher.mongoTLS.certs.caCertKey }}
+  MONGO_TLS_CLIENT_CERT_PATH: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.secretPath }}{{ .Values.mongoDBAuditWatcher.mongoTLS.certs.clientCertKey }}
+  {{ if .Values.mongoDBAuditWatcher.mongoTLS.allowInvalidHosts }}
+  MONGO_TLS_ALLOW_INVALID_HOST: "1" 
+  {{ end }}
+  {{ if .Values.mongoDBAuditWatcher.mongoTLS.certs.clientCertIsEncrypted }}
+  MONGO_TLS_CLIENT_CERT_PASS_KEY: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.clientCertPassKey | quote}}
+  {{ end }}
+  {{ end }}
 

--- a/charts/mongodb-audit-watcher/templates/deployment.yaml
+++ b/charts/mongodb-audit-watcher/templates/deployment.yaml
@@ -45,13 +45,22 @@ spec:
                 name: {{ include "mongodb-audit-watcher.fullname" . }}-config
             - secretRef:
                 name: {{ .Values.mongoDBAuditWatcher.mongoSecret }}
+          {{ if .Values.mongoDBAuditWatcher.mongoTLS.certs.clientCertIsEncrypted }}
+            - secretRef:
+                name: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.clientCertPassSecret }}
+          {{ end }}
           resources:
           {{- toYaml .Values.resources | nindent 12 }}
-          {{ if .Values.persistence.enabled }}
           volumeMounts:
-            - mountPath: {{ .Values.mongoDBAuditWatcher.persistpath }}
+          {{ if .Values.persistence.enabled }}
+            - mountPath: {{ .Values.mongoDBAuditWatcher.persistPath }}
               name: token-store
-      {{ end }}
+          {{ end }}
+           {{ if .Values.mongoDBAuditWatcher.mongoTLS.enabled }}
+            - mountPath: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.secretPath }}
+              name: certs-vol
+              readOnly: true
+          {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -64,3 +73,10 @@ spec:
       tolerations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
+    {{ if .Values.mongoDBAuditWatcher.mongoTLS.enabled }}
+      volumes:
+      - name: certs-vol
+        secret:
+          secretName: {{ .Values.mongoDBAuditWatcher.mongoTLS.certs.secret }}
+    {{ end }}
+

--- a/charts/mongodb-audit-watcher/values.yaml
+++ b/charts/mongodb-audit-watcher/values.yaml
@@ -6,6 +6,7 @@ replicaCount: 1
 
 image:
   repository: dbomproject/mongodb-audit-watcher
+  tag: latest
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -18,6 +19,19 @@ mongoDBAuditWatcher:
   mongoPasswordKey: mongodb-root-password
   mongoSecret: mongodb
   mongoReplicaSetName: rs0
+  mongoServerSelectionTimeout: 3000
+  mongoConnectionTimeout: 3000
+  mongoTLS: 
+    enabled: false
+    allowInvalidHosts: false
+    certs:
+      secret: ""
+      secretPath: /secrets/
+      caCertKey: ca.pem
+      clientCertKey: client.pem
+      clientCertIsEncrypted: false 
+      clientCertPassSecret: ""
+      clientCertPassKey: "MONGO_TLS_CLIENT_CERT_PASS"
 
 logging:
   level: info
@@ -31,7 +45,6 @@ persistence:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  storageClass: nfs-client
   accessMode: ReadWriteOnce
   size: 100Mi
   # existingClaim: ""


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] `helm install --dry-run` has been performed locally
- [x] Lint has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?

Addresses feature request for X509 mutual authentication/authorization (Resolves #3)  

## What is the new behavior?

New configuration parameters added to allow kube-native use of the x509 mutual authentication/authorization provided by the database-agent and mongodb-audit-watcher

In addition this PR contains the following changes:
 - Fix for PORT not applying to database agent
 - Remove explicit storage class and allow default behaviour
 
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

There are no breaking changes as these features are only enabled if `<service>.mongoTLS.enabled` is set to `true` (which is not the default behaviour)

## Other information

All the environment variables that are used to control the new functionality are documented in the READMEs for each chart