### PR TITLE
Remove --build as it is redundant

### DIFF
--- a/docker-compose-quickstart/README.md
+++ b/docker-compose-quickstart/README.md
@@ -28,10 +28,10 @@ Clone this Git repository and navigate to the docker-compose-quickstart folder
 Launch the network using docker-compose
 
 ```
-docker-compose -f docker-compose.yaml up -d --build
+docker-compose -f docker-compose.yaml up -d 
 ```
 
-Once you run this command, the images will be built from the source code and then the containers will be up and running. You can check the status of the containers by running the following command
+Once you run this command, the latest images will be pulled from DockerHub and the containers will come up. If you want to use a specific version of the containers, please edit the compose file to point to the appropriate versions
 
 ```
 docker-compose ps


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## Pull request type

Documentation Update: No need for --build

Please check the type of change your PR introduces:
- [x] Documentation content changes

## What is the current behavior?

The documentation currently states that you need to perform a `docker-compose -f docker-compose.yaml up -d --build`. However since the images are being pulled from dockerhub, the `--build` argument is redundant and ignored by default

## What is the new behavior?

The `--build` argument has been removed and the description line has been updated accordingly 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

This PR only adds extra clarity to the documentation and does not break/fix anything